### PR TITLE
Generalize repo setup for install-docker.sh

### DIFF
--- a/chapter1/install-docker.sh
+++ b/chapter1/install-docker.sh
@@ -55,7 +55,7 @@ echo -e "***********************************************************************
 tput setaf 2
 echo \
   "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  "$(. /etc/os-release && if [ -n "$UBUNTU_CODENAME" ]; then echo "$UBUNTU_CODENAME"; else echo "$VERSION_CODENAME"; fi;)" stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update -y
 


### PR DESCRIPTION
See the "Note" in Section #1:

https://docs.docker.com/engine/install/ubuntu/#set-up-the-repository

I am running on Linux Mint.  To set up the docker repo on any Ubuntu derivative distro, the UBUNTU_CODENAME must be used, not the VERSION_CODENAME.

When I run your code I get the erroneous deb setup in my docker file :

cat /etc/apt/sources.list.d/docker.list
deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu   virginia stable

and apt-update says:

```
root@gillies-VirtualBox:~# sudo apt update
Hit:1 https://dl.google.com/linux/chrome/deb stable InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease                                                                                         
Hit:3 http://security.ubuntu.com/ubuntu jammy-security InRelease                                                                               
Hit:4 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:5 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Ign:6 https://mirrors.ocf.berkeley.edu/linuxmint-packages virginia InRelease
Hit:7 https://mirrors.ocf.berkeley.edu/linuxmint-packages virginia Release
Ign:9 https://download.docker.com/linux/ubuntu virginia InRelease
Err:10 https://download.docker.com/linux/ubuntu virginia Release
  404  Not Found [IP: 54.230.21.59 443]
Reading package lists... Done
E: The repository 'https://download.docker.com/linux/ubuntu virginia Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```

When I run your install-docker.sh code with this bugfix I get :

TESTED=LINUX MINT
```
root@gillies-VirtualBox:~# echo \
  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
  "$(. /etc/os-release && if [ -n "$UBUNTU_CODENAME" ]; then echo "$UBUNTU_CODENAME"; else echo "$VERSION_CODENAME"; fi;)" stable" | \
  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
sudo apt-get update -y
Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Get:4 https://download.docker.com/linux/ubuntu jammy InRelease [48.8 kB]
Hit:5 https://dl.google.com/linux/chrome/deb stable InRelease                                                                                           
Ign:6 https://mirrors.ocf.berkeley.edu/linuxmint-packages virginia InRelease                                         
Hit:7 https://mirrors.ocf.berkeley.edu/linuxmint-packages virginia Release
Get:8 https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages [40.7 kB]
Hit:10 http://security.ubuntu.com/ubuntu jammy-security InRelease           
Fetched 89.5 kB in 5s (16.6 kB/s)
Reading package lists... Done

```

Can you please test this code before you accept and merge the changes, thanks!

- Don Gillies
Palo Alto, CA
http://people.ece.ubc.ca/~gillies